### PR TITLE
ensure AB::MB is specified as configure_requires

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ copyright_year   = 2014
 [AutoPrereqs]
 
 [Alien]
+:version = 0.023
 repo = file:inc
 name = otr
 pattern_prefix = libotr-


### PR DESCRIPTION
This will make sure that configure_requires specifies `Alien::Base::ModuleBuild` instead of `Alien::Base`.  For the rationale for this, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
